### PR TITLE
librewolf: update to version 114.0.2.

### DIFF
--- a/srcpkgs/librewolf/template
+++ b/srcpkgs/librewolf/template
@@ -1,7 +1,7 @@
 # Template file for 'librewolf'
 pkgname=librewolf
-version=114.0.1
-revision=2
+version=114.0.2
+revision=1
 wrksrc=${pkgname}-${version}-${revision}
 build_helper="rust"
 short_desc="LibreWolf web browser"
@@ -9,7 +9,7 @@ maintainer="index <index@tfwno.gf>"
 license="MPL-2.0, GPL-2.0-or-later, LGPL-2.1-or-later"
 homepage="https://librewolf.net/"
 distfiles="https://gitlab.com/api/v4/projects/32320088/packages/generic/librewolf-source/${version}-${revision}/${pkgname}-${version}-${revision}.source.tar.gz"
-checksum=c1374ca1aa1d1e24b24b8c55e4c8c23a1b4fce58b38b1559179dda75368685bd
+checksum=2138e4cb43a480e04c96daea579c6e4179ab3caea8d99539278cf5631819bf27
 
 lib32disabled=yes
 


### PR DESCRIPTION
Heyo mate!

Here's a little PR to update librewolf to the latest release available.
I hope it helped !

Have a good day !