### PR TITLE
update to 149.0.2-1

### DIFF
--- a/srcpkgs/librewolf/template
+++ b/srcpkgs/librewolf/template
@@ -1,6 +1,6 @@
 # Template file for 'librewolf'
 pkgname=librewolf
-version=149.0
+version=149.0.2
 revision=1
 _rev=1
 wrksrc=${pkgname}-${version}-${_rev}
@@ -10,7 +10,7 @@ maintainer="index <index@mailbox.org>"
 license="GPL-3.0-only AND LGPL-2.1-only AND LGPL-3.0-only AND MPL-2.0"
 homepage="https://librewolf.net/"
 distfiles="https://codeberg.org/api/packages/librewolf/generic/librewolf-source/${version}-${_rev}/${pkgname}-${version}-${_rev}.source.tar.gz"
-checksum=5ada766bcf505b9bea0ad473277de8680ba6801d90fb42f00f5cf84e6b410497
+checksum=3c4e7488407d7c0f855c9c41949b833a5dc551685667ea12ecd531c8530d1ccb
 
 lib32disabled=yes
 


### PR DESCRIPTION
fixes some 149 bugs, solid update.
there's also 149.0.2-2 but their CI wasn't happy with tests in full,
so it's safest to go with 149.0.2-1