### PR TITLE
fix building 149.0.2-1

### DIFF
--- a/srcpkgs/librewolf/template
+++ b/srcpkgs/librewolf/template
@@ -198,6 +198,7 @@ do_build() {
 	ac_add_options --with-l10n-base=$PWD/lw/l10n
 
 	export MOZ_REQUIRE_SIGNING=
+	export MOZILLA_OFFICIAL=1
 
 	mk_add_options MOZ_CRASHREPORTER=0
 	mk_add_options MOZ_DATA_REPORTING=0


### PR DESCRIPTION
as of librewolf version 149.0.2-1,librewolf is now designed to be built with export MOZILLA_OFFICIAL=1 set in mozconfig.cfg, and derails into an untested, broken codepath (that only exists in librewolf, not firefox) if it is attempted to be built without having export MOZILLA_OFFICIAL=1 set as per:

https://gitlab.com/librewolf-community/browser/source/-/commit/7cb7143e47cdaaf93d2b35fb632ca7522e2bf2fc
https://codeberg.org/librewolf/source/pulls/97#issuecomment-5654510

According to librewolf developers, they decided to enable export MOZILLA_OFFICIAL=1 because according to this page,

https://searchfox.org/firefox-main/source/toolkit/components/glean/docs/dev/preferences.md#91

"MOZILLA_OFFICIAL tends to be set on most builds released to users, including builds distributed by Linux distributions."

Arch Linux has had it enabled since 2017:

https://gitlab.archlinux.org/archlinux/packaging/packages/firefox/-/commit/ddcebad4fd5eba80d5b99a22bcd11611bfd237b2

before diving deep into the fix, I scoured around just to check if anyone reported something similar, and indeed they have, always worth to check community first for larger projects such as this one :)

much gratitude to the source finder: https://github.com/termux/termux-packages/issues/29252#issuecomment-4204733060